### PR TITLE
fix: Support both string and strings[] in v2.1.0 formdata src field

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,12 @@
+<a name="v0.2.0"></a>
 <a name="v0.1.0"></a>
+
+## v0.2.0 (2021-05-16)
+
+#### Fixes
+
+For collections in chema 2.1.0, requests with body containing form data now correctly expose the src field as being an optional string or an optional vector of strings.
+
 ## v0.1.0 (2018-11-17)
 
 

--- a/src/v2_1_0/mod.rs
+++ b/src/v2_1_0/mod.rs
@@ -443,7 +443,14 @@ pub struct FormParameter {
     pub value: Option<String>,
 
     #[serde(rename = "src")]
-    pub src: Option<String>,
+    pub src: Option<FormParameterSrcUnion>,
+}
+
+#[serde(untagged)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub enum FormParameterSrcUnion {
+    File(String),
+    Files(Vec<String>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]


### PR DESCRIPTION
Reference fix implementation for #2 