### PR TITLE
feat: complete remaining v2.1.0 schema coverage

### DIFF
--- a/src/v2_1_0/mod.rs
+++ b/src/v2_1_0/mod.rs
@@ -50,6 +50,10 @@ pub struct Auth {
     #[serde(rename = "digest")]
     pub digest: Option<Vec<AuthAttribute>>,
 
+    /// The attributes for [Akamai EdgeGrid Authentication](https://techdocs.akamai.com/developer/docs/set-up-authentication-credentials).
+    #[serde(rename = "edgegrid")]
+    pub edgegrid: Option<Vec<AuthAttribute>>,
+
     /// The attributes for [Hawk Authentication](https://github.com/hueniverse/hawk)
     #[serde(rename = "hawk")]
     pub hawk: Option<Vec<AuthAttribute>>,
@@ -406,9 +410,17 @@ pub struct Body {
     #[serde(rename = "formdata")]
     pub formdata: Option<Vec<FormParameter>>,
 
+    /// GraphQL request payload as stored by Postman.
+    #[serde(rename = "graphql")]
+    pub graphql: Option<serde_json::Value>,
+
     /// Postman stores the type of data associated with this request in this field.
     #[serde(rename = "mode")]
     pub mode: Option<Mode>,
+
+    /// Additional configurations and options set for various body modes.
+    #[serde(rename = "options")]
+    pub options: Option<serde_json::Value>,
 
     #[serde(rename = "raw")]
     pub raw: Option<String>,
@@ -589,6 +601,10 @@ pub struct ResponseClass {
     /// response is manually created, this can be set to `null`.
     #[serde(rename = "responseTime")]
     pub response_time: Option<ResponseTime>,
+
+    /// Set of timing information related to request and response in milliseconds.
+    #[serde(rename = "timings")]
+    pub timings: Option<serde_json::Value>,
 
     /// The response status, e.g: '200 OK'
     #[serde(rename = "status")]
@@ -786,6 +802,9 @@ pub enum AuthType {
     #[serde(rename = "digest")]
     Digest,
 
+    #[serde(rename = "edgegrid")]
+    Edgegrid,
+
     #[serde(rename = "hawk")]
     Hawk,
 
@@ -833,6 +852,9 @@ pub enum Mode {
 
     #[serde(rename = "formdata")]
     Formdata,
+
+    #[serde(rename = "graphql")]
+    Graphql,
 
     #[serde(rename = "raw")]
     Raw,

--- a/tests/fixtures/collection/edgegrid-v2.1.0.json
+++ b/tests/fixtures/collection/edgegrid-v2.1.0.json
@@ -1,0 +1,37 @@
+{
+  "auth": {
+    "apikey": null,
+    "awsv4": null,
+    "basic": null,
+    "bearer": null,
+    "digest": null,
+    "edgegrid": [
+      {
+        "key": "accessToken",
+        "type": "string",
+        "value": "edgegrid-access-token"
+      },
+      {
+        "key": "clientToken",
+        "type": "string",
+        "value": "edgegrid-client-token"
+      }
+    ],
+    "hawk": null,
+    "noauth": null,
+    "ntlm": null,
+    "oauth1": null,
+    "oauth2": null,
+    "type": "edgegrid"
+  },
+  "event": null,
+  "info": {
+    "_postman_id": "e1d85d22-58f6-4cc1-a37d-e95d5392d159",
+    "description": null,
+    "name": "EdgeGrid auth v2.1 fixture",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": null
+  },
+  "item": [],
+  "variable": null
+}

--- a/tests/fixtures/collection/graphql-query-v2.1.0.json
+++ b/tests/fixtures/collection/graphql-query-v2.1.0.json
@@ -1,0 +1,63 @@
+{
+  "info": {
+    "_postman_id": "1f6cb533-1fd7-4139-925f-18378d58be26",
+    "name": "GraphQL query fixture",
+    "description": "Minimal v2.1.0 GraphQL collection used for regression coverage.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": null
+  },
+  "item": [
+    {
+      "name": "Run GraphQL query",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "graphql",
+          "graphql": {
+            "query": "query Viewer { viewer { id name } }",
+            "variables": {
+              "includeInactive": false
+            }
+          },
+          "options": {
+            "graphql": {
+              "output": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "https://example.com/graphql",
+          "protocol": "https",
+          "host": [
+            "example",
+            "com"
+          ],
+          "path": [
+            "graphql"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "Viewer response",
+          "status": "OK",
+          "code": 200,
+          "responseTime": 123,
+          "timings": {
+            "response": 123,
+            "dns": 4
+          },
+          "body": "{\"data\":{\"viewer\":{\"id\":\"123\",\"name\":\"Codex\"}}}"
+        }
+      ]
+    }
+  ],
+  "event": [],
+  "variable": null
+}


### PR DESCRIPTION
## Summary
- add the remaining Postman Collection v2.1.0 model support that was still missing from master
- cover GraphQL bodies, body options, response timings, and EdgeGrid auth in the v2.1.0 types
- add focused v2.1.0 fixtures so the existing regression harness round-trips the new fields

## Notes
- this supersedes #7 instead of rebasing the old fork branch
- `apikey` support already landed separately in #10, so this PR intentionally keeps the current `api_key` field name and only fills the remaining gaps

## Verification
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build --examples